### PR TITLE
Add support for official Python & Django versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy-3.7]
+        python-version: [3.8, 3.9, "3.10", "3.11", "pypy-3.9"]
 
     steps:
     - uses: actions/checkout@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,11 @@ Changelog
 0.7.2 (unreleased)
 ------------------
 
-- compatibility with Django 3.1 & 3.2
+- add support for Django 4.1 & 4.2
+- add support for Python 3.10, 3.11
+- drop support for Python 3.5, 3.6 & 3.7
+- drop support for PyPy 3.7
+- add support for PyPy 3.9
 
 
 0.7.1 (2019-12-02)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,4 +273,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3/': None}
+intersphinx_mapping = {'Python 3': ('https://docs.python.org/3/', None)}

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/Zegocover/enmerkar',
     packages=find_packages(exclude=('tests',)),
     install_requires=[
-        'django>=2.2',
+        'django>=3.2',
         'babel>=1.3',
     ],
     classifiers=[
@@ -37,11 +37,10 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Framework :: Django',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python :: Implementation :: CPython',
     ],

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 import unittest
+from io import BytesIO
 
 import pytest
-
 from babel.messages import extract
-from babel._compat import BytesIO
 
 from enmerkar.extract import extract_django
-
 
 default_keys = extract.DEFAULT_KEYWORDS.keys()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,11 @@
 [tox]
-envlist = py{35,36,37,38,39}-django22, py{36,37,38,39}-{django30,django31,django32}, pypy37-{django30,django31,django32}, py{38,39}-{djangomain}, lint, docs
+envlist =
+    py{38,39}-{django32},
+    py{38,39,310,311}-django{41,42},
+    pypy39-django{32,41,42},
+    py{310,311}-{djangomain},
+    lint,
+    docs
 
 [testenv]
 deps =
@@ -7,33 +13,31 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     djangomain: https://github.com/django/django/archive/main.tar.gz#egg=Django
 commands = py.test {posargs}
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.11
 deps =
     sphinx
-    Django>=3.2,<3.3
+    Django>=4.2,<5.0
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/_build/html
     sphinx-build -W -b linkcheck docs {envtmpdir}/_build/html
 
 [testenv:lint]
-basepython = python3.9
+basepython = python3.11
 deps =
-    flake8==3.9.2
+    flake8==6.1.0
 commands=flake8 enmerkar tests
 
 [gh-actions]
 python =
-    3.5: py35
-    3.6: py36
-    3.7: py37
     3.8: py38
-    3.9: py39, lint, docs
-    pypy-3.7: pypy37
+    3.9: py39
+    3.10: py310
+    3.11: py311, lint, docs
+    pypy-3.9: pypy39


### PR DESCRIPTION
Hi,

I've made this PR that

-  add support for Django 4.1 & 4.2
- add support for Python 3.10, 3.11
- drop support for Python 3.5, 3.6 & 3.7
- drop support for PyPy 3.7
- add support for PyPy 3.9

Please can we have new release after this PR is merged?

Thanks,